### PR TITLE
Add support for player-context in singleton item providers

### DIFF
--- a/inventoryaccess/inventory-access-r1/pom.xml
+++ b/inventoryaccess/inventory-access-r1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>xyz.xenondevs.invui</groupId>
         <artifactId>invui-parent</artifactId>
-        <version>1.41</version>
+        <version>1.42</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/inventoryaccess/inventory-access-r10/pom.xml
+++ b/inventoryaccess/inventory-access-r10/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>xyz.xenondevs.invui</groupId>
         <artifactId>invui-parent</artifactId>
-        <version>1.41</version>
+        <version>1.42</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/inventoryaccess/inventory-access-r11/pom.xml
+++ b/inventoryaccess/inventory-access-r11/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>xyz.xenondevs.invui</groupId>
         <artifactId>invui-parent</artifactId>
-        <version>1.41</version>
+        <version>1.42</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/inventoryaccess/inventory-access-r12/pom.xml
+++ b/inventoryaccess/inventory-access-r12/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>xyz.xenondevs.invui</groupId>
         <artifactId>invui-parent</artifactId>
-        <version>1.41</version>
+        <version>1.42</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/inventoryaccess/inventory-access-r13/pom.xml
+++ b/inventoryaccess/inventory-access-r13/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>xyz.xenondevs.invui</groupId>
         <artifactId>invui-parent</artifactId>
-        <version>1.41</version>
+        <version>1.42</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/inventoryaccess/inventory-access-r14/pom.xml
+++ b/inventoryaccess/inventory-access-r14/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>xyz.xenondevs.invui</groupId>
         <artifactId>invui-parent</artifactId>
-        <version>1.41</version>
+        <version>1.42</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/inventoryaccess/inventory-access-r15/pom.xml
+++ b/inventoryaccess/inventory-access-r15/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>xyz.xenondevs.invui</groupId>
         <artifactId>invui-parent</artifactId>
-        <version>1.41</version>
+        <version>1.42</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/inventoryaccess/inventory-access-r16/pom.xml
+++ b/inventoryaccess/inventory-access-r16/pom.xml
@@ -15,7 +15,7 @@
     <properties>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
-        <spigot.version>1.20.1-R0.1-SNAPSHOT</spigot.version>
+        <spigot.version>1.20-R0.1-SNAPSHOT</spigot.version>
     </properties>
 
     <dependencies>

--- a/inventoryaccess/inventory-access-r16/pom.xml
+++ b/inventoryaccess/inventory-access-r16/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>xyz.xenondevs.invui</groupId>
         <artifactId>invui-parent</artifactId>
-        <version>1.41</version>
+        <version>1.42</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
@@ -15,7 +15,7 @@
     <properties>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
-        <spigot.version>1.20-R0.1-SNAPSHOT</spigot.version>
+        <spigot.version>1.20.1-R0.1-SNAPSHOT</spigot.version>
     </properties>
 
     <dependencies>

--- a/inventoryaccess/inventory-access-r17/pom.xml
+++ b/inventoryaccess/inventory-access-r17/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>xyz.xenondevs.invui</groupId>
         <artifactId>invui-parent</artifactId>
-        <version>1.41</version>
+        <version>1.42</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/inventoryaccess/inventory-access-r18/pom.xml
+++ b/inventoryaccess/inventory-access-r18/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>xyz.xenondevs.invui</groupId>
         <artifactId>invui-parent</artifactId>
-        <version>1.41</version>
+        <version>1.42</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/inventoryaccess/inventory-access-r19/pom.xml
+++ b/inventoryaccess/inventory-access-r19/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>xyz.xenondevs.invui</groupId>
         <artifactId>invui-parent</artifactId>
-        <version>1.41</version>
+        <version>1.42</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
@@ -15,7 +15,7 @@
     <properties>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
-        <minecraft.version>1.20.5</minecraft.version>
+        <minecraft.version>1.20.6</minecraft.version>
         <spigot.version>${minecraft.version}-R0.1-SNAPSHOT</spigot.version>
     </properties>
 

--- a/inventoryaccess/inventory-access-r19/pom.xml
+++ b/inventoryaccess/inventory-access-r19/pom.xml
@@ -15,7 +15,7 @@
     <properties>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
-        <minecraft.version>1.20.6</minecraft.version>
+        <minecraft.version>1.20.5</minecraft.version>
         <spigot.version>${minecraft.version}-R0.1-SNAPSHOT</spigot.version>
     </properties>
 

--- a/inventoryaccess/inventory-access-r2/pom.xml
+++ b/inventoryaccess/inventory-access-r2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>xyz.xenondevs.invui</groupId>
         <artifactId>invui-parent</artifactId>
-        <version>1.41</version>
+        <version>1.42</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/inventoryaccess/inventory-access-r20/pom.xml
+++ b/inventoryaccess/inventory-access-r20/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>xyz.xenondevs.invui</groupId>
         <artifactId>invui-parent</artifactId>
-        <version>1.41</version>
+        <version>1.42</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/inventoryaccess/inventory-access-r21/pom.xml
+++ b/inventoryaccess/inventory-access-r21/pom.xml
@@ -15,7 +15,7 @@
     <properties>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
-        <minecraft.version>1.21.3</minecraft.version>
+        <minecraft.version>1.21.2</minecraft.version>
         <spigot.version>${minecraft.version}-R0.1-SNAPSHOT</spigot.version>
     </properties>
 

--- a/inventoryaccess/inventory-access-r21/pom.xml
+++ b/inventoryaccess/inventory-access-r21/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>xyz.xenondevs.invui</groupId>
         <artifactId>invui-parent</artifactId>
-        <version>1.41</version>
+        <version>1.42</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
@@ -15,7 +15,7 @@
     <properties>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
-        <minecraft.version>1.21.2</minecraft.version>
+        <minecraft.version>1.21.3</minecraft.version>
         <spigot.version>${minecraft.version}-R0.1-SNAPSHOT</spigot.version>
     </properties>
 

--- a/inventoryaccess/inventory-access-r3/pom.xml
+++ b/inventoryaccess/inventory-access-r3/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>xyz.xenondevs.invui</groupId>
         <artifactId>invui-parent</artifactId>
-        <version>1.41</version>
+        <version>1.42</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/inventoryaccess/inventory-access-r4/pom.xml
+++ b/inventoryaccess/inventory-access-r4/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>xyz.xenondevs.invui</groupId>
         <artifactId>invui-parent</artifactId>
-        <version>1.41</version>
+        <version>1.42</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/inventoryaccess/inventory-access-r5/pom.xml
+++ b/inventoryaccess/inventory-access-r5/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>xyz.xenondevs.invui</groupId>
         <artifactId>invui-parent</artifactId>
-        <version>1.41</version>
+        <version>1.42</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/inventoryaccess/inventory-access-r6/pom.xml
+++ b/inventoryaccess/inventory-access-r6/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>xyz.xenondevs.invui</groupId>
         <artifactId>invui-parent</artifactId>
-        <version>1.41</version>
+        <version>1.42</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/inventoryaccess/inventory-access-r7/pom.xml
+++ b/inventoryaccess/inventory-access-r7/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>xyz.xenondevs.invui</groupId>
         <artifactId>invui-parent</artifactId>
-        <version>1.41</version>
+        <version>1.42</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/inventoryaccess/inventory-access-r8/pom.xml
+++ b/inventoryaccess/inventory-access-r8/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>xyz.xenondevs.invui</groupId>
         <artifactId>invui-parent</artifactId>
-        <version>1.41</version>
+        <version>1.42</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/inventoryaccess/inventory-access-r9/pom.xml
+++ b/inventoryaccess/inventory-access-r9/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>xyz.xenondevs.invui</groupId>
         <artifactId>invui-parent</artifactId>
-        <version>1.41</version>
+        <version>1.42</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/inventoryaccess/inventory-access/pom.xml
+++ b/inventoryaccess/inventory-access/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>xyz.xenondevs.invui</groupId>
         <artifactId>invui-parent</artifactId>
-        <version>1.41</version>
+        <version>1.42</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/invui-core/pom.xml
+++ b/invui-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>xyz.xenondevs.invui</groupId>
         <artifactId>invui-parent</artifactId>
-        <version>1.41</version>
+        <version>1.42</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/invui-core/src/main/java/xyz/xenondevs/invui/gui/SlotElement.java
+++ b/invui-core/src/main/java/xyz/xenondevs/invui/gui/SlotElement.java
@@ -1,5 +1,6 @@
 package xyz.xenondevs.invui.gui;
 
+import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import xyz.xenondevs.invui.inventory.Inventory;
 import xyz.xenondevs.invui.item.Item;
@@ -11,6 +12,10 @@ import java.util.List;
 public interface SlotElement {
     
     ItemStack getItemStack(String lang);
+
+    default ItemStack getItemStack(Player viewer, String lang) {
+        return getItemStack(lang);
+    }
     
     SlotElement getHoldingElement();
     
@@ -33,7 +38,12 @@ public interface SlotElement {
         public ItemStack getItemStack(String lang) {
             return item.getItemProvider().get(lang);
         }
-        
+
+        @Override
+        public ItemStack getItemStack(Player viewer, String lang) {
+            return item.getItemProvider(viewer).get(lang);
+        }
+
         @Override
         public SlotElement getHoldingElement() {
             return this;
@@ -142,7 +152,12 @@ public interface SlotElement {
             SlotElement holdingElement = getHoldingElement();
             return holdingElement != null ? holdingElement.getItemStack(lang) : null;
         }
-        
+
+        @Override
+        public ItemStack getItemStack(Player viewer, String lang) {
+            SlotElement holdingElement = getHoldingElement();
+            return holdingElement != null ? holdingElement.getItemStack(viewer, lang) : null;
+        }
     }
     
 }

--- a/invui-core/src/main/java/xyz/xenondevs/invui/gui/SlotElement.java
+++ b/invui-core/src/main/java/xyz/xenondevs/invui/gui/SlotElement.java
@@ -12,7 +12,7 @@ import java.util.List;
 public interface SlotElement {
     
     ItemStack getItemStack(String lang);
-
+    
     default ItemStack getItemStack(Player viewer, String lang) {
         return getItemStack(lang);
     }
@@ -38,12 +38,12 @@ public interface SlotElement {
         public ItemStack getItemStack(String lang) {
             return item.getItemProvider().get(lang);
         }
-
+        
         @Override
         public ItemStack getItemStack(Player viewer, String lang) {
             return item.getItemProvider(viewer).get(lang);
         }
-
+        
         @Override
         public SlotElement getHoldingElement() {
             return this;
@@ -152,7 +152,7 @@ public interface SlotElement {
             SlotElement holdingElement = getHoldingElement();
             return holdingElement != null ? holdingElement.getItemStack(lang) : null;
         }
-
+        
         @Override
         public ItemStack getItemStack(Player viewer, String lang) {
             SlotElement holdingElement = getHoldingElement();

--- a/invui-core/src/main/java/xyz/xenondevs/invui/item/Item.java
+++ b/invui-core/src/main/java/xyz/xenondevs/invui/item/Item.java
@@ -20,6 +20,17 @@ public interface Item {
      * @return The {@link ItemProvider}
      */
     ItemProvider getItemProvider();
+
+    /**
+     * Gets the {@link ItemProvider} for a specific {@link Player}.
+     * This method gets called every time a {@link Window} is notified ({@link #notifyWindows()}).
+     * <p>The default implementation delegates to {@link #getItemProvider()}</p>
+     * @param viewer the viewer (provides context for rendering player-specific information in the item)
+     * @return The {@link ItemProvider}
+     */
+    default ItemProvider getItemProvider(Player viewer) {
+        return getItemProvider();
+    }
     
     /**
      * Adds an {@link AbstractWindow} to the window set, telling the {@link Item} that it is

--- a/invui-core/src/main/java/xyz/xenondevs/invui/item/Item.java
+++ b/invui-core/src/main/java/xyz/xenondevs/invui/item/Item.java
@@ -18,8 +18,11 @@ public interface Item {
      * This method gets called every time a {@link Window} is notified ({@link #notifyWindows()}).
      *
      * @return The {@link ItemProvider}
+     * @throws UnsupportedOperationException if neither this method nor {@link #getItemProvider(Player)} is overridden
      */
-    ItemProvider getItemProvider();
+    default ItemProvider getItemProvider() {
+        throw new UnsupportedOperationException("Either getItemProvider() or getItemProvider(Player) must be overridden!");
+    }
     
     /**
      * Gets the {@link ItemProvider} for a specific {@link Player}.

--- a/invui-core/src/main/java/xyz/xenondevs/invui/item/Item.java
+++ b/invui-core/src/main/java/xyz/xenondevs/invui/item/Item.java
@@ -20,11 +20,12 @@ public interface Item {
      * @return The {@link ItemProvider}
      */
     ItemProvider getItemProvider();
-
+    
     /**
      * Gets the {@link ItemProvider} for a specific {@link Player}.
      * This method gets called every time a {@link Window} is notified ({@link #notifyWindows()}).
      * <p>The default implementation delegates to {@link #getItemProvider()}</p>
+     *
      * @param viewer the viewer (provides context for rendering player-specific information in the item)
      * @return The {@link ItemProvider}
      */

--- a/invui-core/src/main/java/xyz/xenondevs/invui/window/AbstractWindow.java
+++ b/invui-core/src/main/java/xyz/xenondevs/invui/window/AbstractWindow.java
@@ -89,7 +89,7 @@ public abstract class AbstractWindow implements Window, GuiParent {
     protected void redrawItem(int index, SlotElement element, boolean setItem) {
         // put ItemStack in inventory
         ItemStack itemStack;
-        if (element == null || (element instanceof SlotElement.InventorySlotElement && element.getItemStack(getLang()) == null)) {
+        if (element == null || (element instanceof SlotElement.InventorySlotElement && element.getItemStack(this.viewer, getLang()) == null)) {
             ItemProvider background = getGuiAt(index).getFirst().getBackground();
             itemStack = background == null ? null : background.get(getLang());
         } else if (element instanceof SlotElement.LinkedSlotElement && element.getHoldingElement() == null) {
@@ -106,7 +106,7 @@ public abstract class AbstractWindow implements Window, GuiParent {
             itemStack = background == null ? null : background.get(getLang());
         } else {
             SlotElement holdingElement = element.getHoldingElement();
-            itemStack = holdingElement.getItemStack(getLang());
+            itemStack = holdingElement.getItemStack(this.viewer, getLang());
             
             if (holdingElement instanceof SlotElement.ItemSlotElement) {
                 // This makes every item unique to prevent Shift-DoubleClick "clicking" multiple items at the same time.

--- a/invui-kotlin/pom.xml
+++ b/invui-kotlin/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>xyz.xenondevs.invui</groupId>
         <artifactId>invui-parent</artifactId>
-        <version>1.41</version>
+        <version>1.42</version>
     </parent>
 
     <artifactId>invui-kotlin</artifactId>

--- a/invui/pom.xml
+++ b/invui/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>xyz.xenondevs.invui</groupId>
         <artifactId>invui-parent</artifactId>
-        <version>1.41</version>
+        <version>1.42</version>
     </parent>
 
     <artifactId>invui</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>xyz.xenondevs.invui</groupId>
     <artifactId>invui-parent</artifactId>
-    <version>1.41</version>
+    <version>1.42</version>
     <packaging>pom</packaging>
 
     <properties>


### PR DESCRIPTION
This PR adds a new method to the Item interface: `getItemProvider(Player)`

With the default implementation, this simply delegates to the existing `getItemProvider()` method, leaving existing implementations unchanged.

However, for cases where an Item in a GUI needs to display information about the player viewing them (e.g. Show the player name as the item display name or in the item lore) the only way to achieve this currently is to create a GUI per player, which is more costly especially for larger servers where the ideal implementation for resource usage is a singleton GUI & singleton Items and only having player-specific Windows.

This PR enables this functionality by passing the Window's viewer through to the `Item#getItemProvider(Player)` method.

The PR builds successfully and I have tested both existing and the new functionality on Spigot 1.21.3 and Paper 1.21.3 and can confirm this works as intended.