### PR TITLE
Move dependency declaration to version catalog

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -9,7 +9,7 @@ repositories {
 
 dependencies {
     implementation(libs.paper.paperweightUserdev.plugin)
-
+    
     // https://github.com/gradle/gradle/issues/15383#issuecomment-779893192
     implementation(files(libs.javaClass.superclass.protectionDomain.codeSource.location))
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -4,8 +4,12 @@ plugins {
 
 repositories {
     gradlePluginPortal()
+    maven("https://repo.papermc.io/repository/maven-public/")
 }
 
 dependencies {
-    implementation("io.papermc.paperweight:paperweight-userdev:1.7.5")
+    implementation(libs.paper.paperweightUserdev.plugin)
+
+    // https://github.com/gradle/gradle/issues/15383#issuecomment-779893192
+    implementation(files(libs.javaClass.superclass.protectionDomain.codeSource.location))
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -4,11 +4,10 @@ plugins {
 
 repositories {
     gradlePluginPortal()
-    maven("https://repo.papermc.io/repository/maven-public/")
 }
 
 dependencies {
-    implementation(libs.paper.paperweightUserdev.plugin)
+    implementation(libs.paperweight.userdev.plugin)
     
     // https://github.com/gradle/gradle/issues/15383#issuecomment-779893192
     implementation(files(libs.javaClass.superclass.protectionDomain.codeSource.location))

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -1,0 +1,7 @@
+dependencyResolutionManagement {
+    versionCatalogs {
+        create("libs") {
+            from(files("../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/buildSrc/src/main/kotlin/invui.common-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/invui.common-conventions.gradle.kts
@@ -1,5 +1,4 @@
-group = "xyz.xenondevs.invui"
-version = "2.0.0-alpha.6"
+import org.gradle.accessors.dm.LibrariesForLibs
 
 plugins {
     `java-library`
@@ -7,22 +6,27 @@ plugins {
     id("io.papermc.paperweight.userdev")
 }
 
+val libs = the<LibrariesForLibs>()
+
+group = "xyz.xenondevs.invui"
+version = "2.0.0-alpha.6"
+
 repositories {
     mavenCentral()
     maven("https://repo.papermc.io/maven-public/")
 }
 
 dependencies {
-    paperweight.paperDevBundle("1.21.4-R0.1-SNAPSHOT")
-    implementation("org.jetbrains:annotations:26.0.1")
-    implementation("org.jspecify:jspecify:1.0.0")
-    
-    testImplementation(platform("org.junit:junit-bom:5.11.4"))
-    testImplementation("org.junit.jupiter:junit-jupiter")
-    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
-    testImplementation("org.mockbukkit.mockbukkit:mockbukkit-v1.21:4.20.0")
+    paperweight.paperDevBundle(libs.versions.paper.api.get())
+    implementation(libs.jetbrains.annotations)
+    implementation(libs.jspecify)
+
+    testImplementation(platform(libs.junit.bom))
+    testImplementation(libs.junit.jupiter)
+    testRuntimeOnly(libs.junit.platformLauncher)
+    testImplementation(libs.mockbukkit)
     configurations.getByName("testImplementation").exclude("io.papermc.paper", "paper-server")
-    testImplementation("ch.qos.logback:logback-classic:1.5.13")
+    testImplementation(libs.logback.classic)
 }
 
 java {

--- a/buildSrc/src/main/kotlin/invui.common-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/invui.common-conventions.gradle.kts
@@ -17,7 +17,7 @@ repositories {
 }
 
 dependencies {
-    paperweight.paperDevBundle(libs.versions.paper.api.get())
+    paperweight.paperDevBundle(libs.versions.paper.get())
     implementation(libs.jetbrains.annotations)
     implementation(libs.jspecify)
     

--- a/buildSrc/src/main/kotlin/invui.common-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/invui.common-conventions.gradle.kts
@@ -25,8 +25,6 @@ dependencies {
     testImplementation(libs.junit.jupiter)
     testRuntimeOnly(libs.junit.platformLauncher)
     testImplementation(libs.mockbukkit)
-    configurations.getByName("testImplementation")
-        .exclude("io.papermc.paper", "paper-server")
     testImplementation(libs.logback.classic)
 }
 

--- a/buildSrc/src/main/kotlin/invui.common-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/invui.common-conventions.gradle.kts
@@ -25,7 +25,8 @@ dependencies {
     testImplementation(libs.junit.jupiter)
     testRuntimeOnly(libs.junit.platformLauncher)
     testImplementation(libs.mockbukkit)
-    configurations.getByName("testImplementation").exclude("io.papermc.paper", "paper-server")
+    configurations.getByName("testImplementation")
+        .exclude("io.papermc.paper", "paper-server")
     testImplementation(libs.logback.classic)
 }
 
@@ -34,6 +35,10 @@ java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(21)
     }
+}
+
+paperweight {
+    addServerDependencyTo = configurations.named(JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME).map { setOf(it) }
 }
 
 tasks {

--- a/buildSrc/src/main/kotlin/invui.common-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/invui.common-conventions.gradle.kts
@@ -20,7 +20,7 @@ dependencies {
     paperweight.paperDevBundle(libs.versions.paper.api.get())
     implementation(libs.jetbrains.annotations)
     implementation(libs.jspecify)
-
+    
     testImplementation(platform(libs.junit.bom))
     testImplementation(libs.junit.jupiter)
     testRuntimeOnly(libs.junit.platformLauncher)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,21 +1,18 @@
 [versions]
-paper-paperweightUserdev = "2.0.0-SNAPSHOT"
-paper-api = "1.21.4-R0.1-SNAPSHOT"
-jetbrains-annotations = "26.0.1"
-jspecify = "1.0.0"
-junit = "5.11.4"
-mockbukkit = "4.20.0"
-logback-classic = "1.5.13"
+kotlin = "2.1.0"
+paper = "1.21.4-R0.1-SNAPSHOT"
 
 [libraries]
-jetbrains-annotations = { module = "org.jetbrains:annotations", version.ref = "jetbrains-annotations" }
-jspecify = { module = "org.jspecify:jspecify", version.ref = "jspecify" }
-junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }
-junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit" }
+commons-provider = { module = "xyz.xenondevs.commons:commons-provider", version = "1.24" }
+jetbrains-annotations = { module = "org.jetbrains:annotations", version = "26.0.1" }
+jspecify = { module = "org.jspecify:jspecify", version = "1.0.0" }
+junit-bom = { module = "org.junit:junit-bom", version = "5.11.4" }
+junit-jupiter = { module = "org.junit.jupiter:junit-jupiter" }
 junit-platformLauncher = { module = "org.junit.platform:junit-platform-launcher" }
-mockbukkit = { module = "org.mockbukkit.mockbukkit:mockbukkit-v1.21", version.ref = "mockbukkit" }
-logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "logback-classic" }
-paper-paperweightUserdev-plugin = { module = "io.papermc.paperweight:paperweight-userdev", version.ref = "paper-paperweightUserdev" }
+kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
+mockbukkit = { module = "org.mockbukkit.mockbukkit:mockbukkit-v1.21", version = "4.20.0" }
+logback-classic = { module = "ch.qos.logback:logback-classic", version = "1.5.13" }
+paperweight-userdev-plugin = { module = "io.papermc.paperweight:paperweight-userdev", version = "2.0.0-beta.8" }
 
 [plugins]
-paper-paperweightUserdev = { id = "io.papermc.paperweight.userdev", version.ref = "paper-paperweightUserdev" }
+kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,21 @@
+[versions]
+paper-paperweightUserdev = "2.0.0-SNAPSHOT"
+paper-api = "1.21.4-R0.1-SNAPSHOT"
+jetbrains-annotations = "26.0.1"
+jspecify = "1.0.0"
+junit = "5.11.4"
+mockbukkit = "4.20.0"
+logback-classic = "1.5.13"
+
+[libraries]
+jetbrains-annotations = { module = "org.jetbrains:annotations", version.ref = "jetbrains-annotations" }
+jspecify = { module = "org.jspecify:jspecify", version.ref = "jspecify" }
+junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }
+junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit" }
+junit-platformLauncher = { module = "org.junit.platform:junit-platform-launcher" }
+mockbukkit = { module = "org.mockbukkit.mockbukkit:mockbukkit-v1.21", version.ref = "mockbukkit" }
+logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "logback-classic" }
+paper-paperweightUserdev-plugin = { module = "io.papermc.paperweight:paperweight-userdev", version.ref = "paper-paperweightUserdev" }
+
+[plugins]
+paper-paperweightUserdev = { id = "io.papermc.paperweight.userdev", version.ref = "paper-paperweightUserdev" }

--- a/invui-kotlin/build.gradle.kts
+++ b/invui-kotlin/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     id("invui.common-conventions")
-    kotlin("jvm") version "2.1.0"
+    alias(libs.plugins.kotlin)
 }
 
 repositories {
@@ -14,9 +14,9 @@ repositories {
 }
 
 dependencies {
-    api("org.jetbrains.kotlin:kotlin-stdlib:2.1.0")
     api(project(":invui"))
-    api("xyz.xenondevs.commons:commons-provider:1.23")
+    api(libs.kotlin.stdlib)
+    api(libs.commons.provider)
 }
 
 publishing {


### PR DESCRIPTION
I suggest to use the gradle version catalog to declare dependencies to have a central spot to manage dependencies.

Also bumped paperweight to 2.0.0-SNAPSHOT and added that paperweight 2 doesn't include paper nms to tests.