### PR TITLE
Fix event flood bug

### DIFF
--- a/invui-core/src/main/java/xyz/xenondevs/invui/inventory/Inventory.java
+++ b/invui-core/src/main/java/xyz/xenondevs/invui/inventory/Inventory.java
@@ -833,14 +833,17 @@ public abstract class Inventory {
             newStack.setAmount(Math.min(amountLeft, getMaxSlotStackSize(slot, itemStack)));
             if (shouldCallEvents(updateReason)) {
                 ItemPreUpdateEvent event = callPreUpdateEvent(updateReason, slot, null, newStack);
-                if (!event.isCancelled()) {
-                    newStack = event.getNewItem();
-                    setCloneBackingItem(slot, newStack);
-                    callPostUpdateEvent(updateReason, slot, null, newStack);
-                    
-                    int newStackAmount = newStack != null ? newStack.getAmount() : 0;
-                    amountLeft -= newStackAmount;
+                if (event.isCancelled()) {
+                    break; //This is in-line with Bukkit's behavior, if an event is cancelled while adding to an inventory, stop trying to add further
                 }
+                newStack = event.getNewItem();
+                setCloneBackingItem(slot, newStack);
+                callPostUpdateEvent(updateReason, slot, null, newStack);
+
+                int newStackAmount = newStack != null ? newStack.getAmount() : 0;
+                amountLeft -= newStackAmount;
+                if (amountLeft == 0) break;  //Break since the item has been placed
+
             } else {
                 setDirectBackingItem(slot, newStack);
                 amountLeft -= newStack.getAmount();


### PR DESCRIPTION
There is an issue with this piece of code.
the PreUpdateEvent is called on every empty slots even if the item has been already placed or if the event is cancelled.
This is not the normal behaviour expected like in the Bukkit event