### PR TITLE
publicize container id

### DIFF
--- a/invui/src/main/java/xyz/xenondevs/invui/internal/menu/CustomContainerMenu.java
+++ b/invui/src/main/java/xyz/xenondevs/invui/internal/menu/CustomContainerMenu.java
@@ -631,7 +631,15 @@ public abstract class CustomContainerMenu {
             throw new IllegalStateException("Window is not set");
         return (WindowEventListener) window;
     }
-    
+
+    /**
+     * Gets the container ID (window ID) for the window
+     * @return the container id, or -1 if the window isn't a container
+     */
+    public int getContainerId() {
+        return containerId;
+    }
+
     /**
      * A proxy {@link AbstractContainerMenu} for intercepting carried item change and general bukkit interoperability.
      */

--- a/invui/src/main/java/xyz/xenondevs/invui/window/AbstractWindow.java
+++ b/invui/src/main/java/xyz/xenondevs/invui/window/AbstractWindow.java
@@ -703,7 +703,12 @@ non-sealed abstract class AbstractWindow<M extends CustomContainerMenu> implemen
     public int getClientWindowState() {
         return clientWindowState;
     }
-    
+
+    @Override
+    public int getContainerId() {
+        return menu.getContainerId();
+    }
+
     @Override
     public void handlePong(int id) {
         clientWindowState = id;

--- a/invui/src/main/java/xyz/xenondevs/invui/window/Window.java
+++ b/invui/src/main/java/xyz/xenondevs/invui/window/Window.java
@@ -301,7 +301,15 @@ public sealed interface Window extends Observer permits AbstractWindow, AnvilWin
      * @param handler The window state change handler to remove
      */
     void removeWindowStateChangeHandler(Consumer<? super Integer> handler);
-    
+
+    /**
+     * Gets the container ID (window ID) for the window
+     * @return the container id, or -1 if the window isn't a container
+     */
+    default int getContainerId() {
+        return -1;
+    }
+
     /**
      * A {@link Window} builder.
      *


### PR DESCRIPTION
Publicize the container id of a Window to primarily allow properly closing menus on the Bedrock Platform.
Bedrock has an issue where you cannot close a InvUI Packet Container because the Bukkit `Player#closeInventory` method cannot close the menu without a proper container id being specified, the only way to resolve this is to manually send the close container packet yourself with the container id attached so Bedrock Clients can properly close InvUI Menus