### PR TITLE
Fix strange initialization issue in PacketListener

### DIFF
--- a/invui/src/main/java/xyz/xenondevs/invui/internal/network/PacketListener.java
+++ b/invui/src/main/java/xyz/xenondevs/invui/internal/network/PacketListener.java
@@ -102,7 +102,12 @@ public class PacketListener implements Listener {
         var channel = ((CraftPlayer) player).getHandle().connection.connection.channel;
         var packetHandler = new PacketHandler(player, channel);
         packetHandlers.put(player.getUniqueId(), packetHandler);
-        channel.pipeline().addBefore(MC_PACKET_HANDLER_NAME, invuiPacketHandlerName, packetHandler);
+        try {
+            channel.pipeline().addBefore(MC_PACKET_HANDLER_NAME, invuiPacketHandlerName, packetHandler);
+        } catch (NoSuchElementException e) {
+            // When player disconnected with unknown reason, the handler injection might fail.
+            // just catch and ignore the exception to ensure PacketListener initializes.
+        }
     }
     
     private void removeChannelHandler(Player player) {

--- a/invui/src/main/java/xyz/xenondevs/invui/internal/network/PacketListener.java
+++ b/invui/src/main/java/xyz/xenondevs/invui/internal/network/PacketListener.java
@@ -104,7 +104,7 @@ public class PacketListener implements Listener {
         packetHandlers.put(player.getUniqueId(), packetHandler);
         try {
             channel.pipeline().addBefore(MC_PACKET_HANDLER_NAME, invuiPacketHandlerName, packetHandler);
-        } catch (NoSuchElementException e) {
+        } catch (NoSuchElementException ignored) {
             // When player disconnected with unknown reason, the handler injection might fail.
             // just catch and ignore the exception to ensure PacketListener initializes.
         }

--- a/invui/src/main/java/xyz/xenondevs/invui/internal/network/PacketListener.java
+++ b/invui/src/main/java/xyz/xenondevs/invui/internal/network/PacketListener.java
@@ -104,9 +104,10 @@ public class PacketListener implements Listener {
         packetHandlers.put(player.getUniqueId(), packetHandler);
         try {
             channel.pipeline().addBefore(MC_PACKET_HANDLER_NAME, invuiPacketHandlerName, packetHandler);
-        } catch (NoSuchElementException ignored) {
-            // When player disconnected with unknown reason, the handler injection might fail.
-            // just catch and ignore the exception to ensure PacketListener initializes.
+        } catch (NoSuchElementException e) {
+            // https://github.com/NichtStudioCode/InvUI/pull/119
+            InvUI.getInstance().getPlugin().getComponentLogger()
+                .error("[InvUI] Failed to inject packet handler for player {}: {}. InvUI will not work correctly for this player.", player.getName(), e.getMessage());
         }
     }
     


### PR DESCRIPTION
Similar issues have been observed in other plugins before:
https://github.com/DecentSoftware-eu/DecentHolograms/issues/219

During the initialization of the PacketListener class, InvUI attempts to iterate through the online player list and inject handlers. If any individual player's Netty channel encounters an abnormal status, it can trigger this specific issue.

Consequently, this breaks the initialization completely, preventing all players from opening any InvUI menus until the server is restarted.