### PR TITLE
Resolve grouping of unresolved types that likely should result in none > unsupported type

### DIFF
--- a/invui/src/main/java/xyz/xenondevs/invui/internal/menu/CustomContainerMenu.java
+++ b/invui/src/main/java/xyz/xenondevs/invui/internal/menu/CustomContainerMenu.java
@@ -455,6 +455,8 @@ public abstract class CustomContainerMenu {
                 handlePong(p);
                 yield UpdateType.NONE;
             }
+            case ServerboundContainerButtonClickPacket _, ServerboundContainerClickPacket _,
+                 ServerboundContainerClosePacket _ -> UpdateType.NONE;
             default -> throw new UnsupportedOperationException("Unknown packet type: " + packet.getClass().getName());
         };
     }


### PR DESCRIPTION
I ran into an obscure issue that I "best resolved" by setting these types to "none" when upgrading from Minecraft 26.1 -> 26.2 (or from InvUI 2.1.1 -> 2.2.0).

Example warning: https://mclo.gs/ebZ1Oke (I confirmed this patch DOES minimize the trip).

The action processed correctly (changing an item stack with a customary ShopGUIPlus-like module via adding or removing items). I can't see specific use cases that should be natively defined; thus, I went ahead and proceeded down this route. Let me know if this is wrong or if you'd like this done differently!